### PR TITLE
Make base URI final after revealing.

### DIFF
--- a/contracts/NFT/NFT_REVEAL.sol
+++ b/contracts/NFT/NFT_REVEAL.sol
@@ -21,7 +21,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract NFT is ERC721Enumerable, Ownable {
   using Strings for uint256;
 
-  string public baseURI;
+  string public baseURI = "";
   string public baseExtension = ".json";
   uint256 public cost = 0.05 ether;
   uint256 public maxSupply = 10000;
@@ -34,10 +34,8 @@ contract NFT is ERC721Enumerable, Ownable {
   constructor(
     string memory _name,
     string memory _symbol,
-    string memory _initBaseURI,
     string memory _initNotRevealedUri
   ) ERC721(_name, _symbol) {
-    setBaseURI(_initBaseURI);
     setNotRevealedURI(_initNotRevealedUri);
     mint(msg.sender, 20);
   }
@@ -102,10 +100,12 @@ contract NFT is ERC721Enumerable, Ownable {
   }
 
   //only owner
-  function reveal() public onlyOwner {
-      revealed = true;
+  function reveal(string memory _finalBaseURI) public onlyOwner {
+    require(revealed == false);
+    baseURI = _finalBaseURI;
+    revealed = true;
   }
-  
+
   function setCost(uint256 _newCost) public onlyOwner {
     cost = _newCost;
   }
@@ -116,10 +116,6 @@ contract NFT is ERC721Enumerable, Ownable {
   
   function setNotRevealedURI(string memory _notRevealedURI) public onlyOwner {
     notRevealedUri = _notRevealedURI;
-  }
-
-  function setBaseURI(string memory _newBaseURI) public onlyOwner {
-    baseURI = _newBaseURI;
   }
 
   function setBaseExtension(string memory _newBaseExtension) public onlyOwner {


### PR DESCRIPTION
hey guys. it seems like a lot of NFTs in the wild are copying the code from the tutorials and IMO it would be great to lead by a strong example!
currently, the NFT contract supports overriding of the base URI at any time. this makes NFTs untrustworthy bc you're at the mercy of the initial creator to not change any of the metadata. what do you think about only allowing metadata to be set once, exactly when the reveal happens? that way a) the base uri is hidden before reveal ( #19 ) and b) I'd take a similar 'only once' logic inside that method to make sure the baseURI can only be set once initially. cheers!

https://twitter.com/TheRaccoonSS/status/1434952984857911300?s=20

https://discord.com/channels/889036571385409556/889645060243726427/922275079017099294